### PR TITLE
v0.4.0: Full RTP header parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.4.0] - 2026-04-08
+
 ### Changed
 
 - RTP header removal now parses full header (CSRC entries, extension headers) instead of assuming fixed 12 bytes
@@ -32,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New tool pcap-replay that resends all UDP packets carrying UDP/TS or UDP/RTP/TS streams
 - initial version of the repo
 
-[Unreleased]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.3.0...HEAD
-[0.3.0]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.3.0...v0.3.0
+[Unreleased]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.4.0...HEAD
+[0.4.0]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Changed
+
+- RTP header removal now parses full header (CSRC entries, extension headers) instead of assuming fixed 12 bytes
+- Shared RTP header parsing between pcap-unpack and pcap-replay
 
 ## [0.3.0] - 2025-11-19
 

--- a/cmd/pcap-replay/sender.go
+++ b/cmd/pcap-replay/sender.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Eyevinn/pcap-tools/internal"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -101,12 +102,9 @@ func (u *udpHandler) AddPacket(dst string, udpPayload []byte, timestamp time.Tim
 	u.firstSame = -1
 
 	ok = true
-	switch extraBytes {
-	case 0: // One or more TS packets
-		// Do nothing
-	case 12: // RTP. Remove 12-byte header
-		udpPayload = udpPayload[12:]
-	default:
+	if hdrLen := internal.RTPHeaderLen(udpPayload); hdrLen > 0 {
+		udpPayload = udpPayload[hdrLen:]
+	} else if extraBytes != 0 {
 		ok = false // only count, nothing else
 		if u.streams[dst] {
 			log.Infof("stream %q: udp payload size %d indicates not a TS stream", dst, len(udpPayload))

--- a/cmd/pcap-unpack/pcap.go
+++ b/cmd/pcap-unpack/pcap.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Eyevinn/pcap-tools/internal"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
@@ -72,18 +73,8 @@ func processPcapHandle(handle *pcap.Handle, fileName, dstDir string) error {
 		}
 		fh := udpDsts[dst]
 		payload := udp.Payload
-		hdrLen := len(payload) % 188
-
-		switch hdrLen {
-		case 0:
-			// Pure TS, do nothing
-		case 12:
-			// Assume RTP header of length 12 and remove it if sync byte found
-			if payload[12] == 0x47 {
-				payload = payload[12:]
-			}
-		default:
-			// Unknown header length, write anyway
+		if hdrLen := internal.RTPHeaderLen(payload); hdrLen > 0 {
+			payload = payload[hdrLen:]
 		}
 		_, err := fh.Write(payload)
 		if err != nil {

--- a/internal/rtp.go
+++ b/internal/rtp.go
@@ -1,0 +1,43 @@
+package internal
+
+import "encoding/binary"
+
+// RTPHeaderLen returns the full RTP header length if payload starts with a valid
+// RTP header followed by a TS sync byte (0x47). Returns 0 if not RTP.
+//
+// RTP header layout (RFC 3550):
+//
+//	 0               1
+//	 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7
+//	+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+//	|V=2|P|X|  CC   |M|     PT      | ...
+//
+// Header length = 12 + CC*4 [+ 4 + extLen*4 if X is set]
+func RTPHeaderLen(payload []byte) int {
+	if len(payload) < 12 {
+		return 0
+	}
+	// Version must be 2
+	if payload[0]>>6 != 2 {
+		return 0
+	}
+	cc := int(payload[0] & 0x0F)
+	hdrLen := 12 + cc*4
+	// Extension header
+	if payload[0]&0x10 != 0 {
+		extOffset := hdrLen
+		if len(payload) < extOffset+4 {
+			return 0
+		}
+		extWords := int(binary.BigEndian.Uint16(payload[extOffset+2 : extOffset+4]))
+		hdrLen = extOffset + 4 + extWords*4
+	}
+	if len(payload) <= hdrLen {
+		return 0
+	}
+	// Verify TS sync byte follows
+	if payload[hdrLen] != 0x47 {
+		return 0
+	}
+	return hdrLen
+}

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	commitVersion string = "v0.3"       // May be updated using build flags
+	commitVersion string = "v0.4.0"       // May be updated using build flags
 	commitDate    string = "1763545288" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 


### PR DESCRIPTION
## Summary
- RTP header removal now parses the full header (CSRC entries, extension headers) instead of assuming a fixed 12-byte size
- Shared RTP header parsing logic between pcap-unpack and pcap-replay via internal/rtp.go
- Bumped version to v0.4.0

## Test plan
- [ ] Run pcap-unpack on captures with standard 12-byte RTP headers
- [ ] Run pcap-unpack on captures with CSRC or extension headers
- [ ] Run pcap-replay and verify RTP stripping works correctly