### PR TITLE
ci: fix lint job and update actions to Node 24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -25,7 +25,7 @@ jobs:
         run: sudo apt install -y libpcap-dev
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download Go dependencies
         run: go mod download

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,19 +12,16 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.22
           cache: false
+      - name: Install libpcap-dev
+        run: sudo apt install -y libpcap-dev
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.54.2
-          args: --skip-files=xml
-          only-new-issues: true
-      - name: go-report-card
-        uses: creekorful/goreportcard-action@v1.0
-        with:
+          version: v2.12.2
           only-new-issues: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,29 @@
+version: "2"
 linters:
   enable:
     - lll
-
-linters-settings:
-  lll:
-    # max line length, lines longer will be reported. Default is 120.
-    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
-    line-length: 120
-    # tab width in spaces. Default to 1.
-    tab-width: 4
+  settings:
+    lll:
+      # max line length, lines longer will be reported. Default is 120.
+      # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+      line-length: 120
+      # tab width in spaces. Default to 1.
+      tab-width: 4
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/pcap-replay/sender.go
+++ b/cmd/pcap-replay/sender.go
@@ -66,8 +66,8 @@ func (u *udpHandler) AddPacket(dst string, udpPayload []byte, timestamp time.Tim
 		u.streams[dst] = true
 		log.Infof("Found new UDP stream %s", dst)
 		if u.dstDir != "" {
-			dstFileName := strings.Replace(dst, ".", "_", -1)
-			dstFileName = strings.Replace(dstFileName, ":", "_", -1) + ".ts"
+			dstFileName := strings.ReplaceAll(dst, ".", "_")
+			dstFileName = strings.ReplaceAll(dstFileName, ":", "_") + ".ts"
 			dstFilePath := path.Join(u.dstDir, dstFileName)
 			err := os.MkdirAll(u.dstDir, os.ModePerm)
 			if err != nil {

--- a/cmd/pcap-unpack/pcap.go
+++ b/cmd/pcap-unpack/pcap.go
@@ -57,8 +57,8 @@ func processPcapHandle(handle *pcap.Handle, fileName, dstDir string) error {
 			// Remove file extension from input filename (e.g., .pcap)
 			baseName := filepath.Base(fileName)
 			baseNameWithoutExt := strings.TrimSuffix(baseName, filepath.Ext(baseName))
-			switch {
-			case dstDir == "":
+			switch dstDir {
+			case "":
 				dstPath = fmt.Sprintf("%s_%s", baseNameWithoutExt, dst)
 			default:
 				dstPath = filepath.Join(dstDir, fmt.Sprintf("%s_%s", baseNameWithoutExt, dst))


### PR DESCRIPTION
## Why

The `lint` job was failing: `golangci-lint`'s typecheck couldn't compile `github.com/google/gopacket/pcap` because the runner lacked libpcap's C header (`pcap.h`). CI also warned that several actions still ship as Node 20, which GitHub is deprecating.

## Changes

**Fix the lint failure**
- Install `libpcap-dev` in the lint workflow before `golangci-lint` runs (the build workflow already did this).

**Clear the Node 20 deprecation warning**
- `go.yml`: `setup-go@v3 → v6`, `checkout@v4 → v5`
- `golangci-lint.yml`: `checkout@v3 → v5`, `setup-go@v4 → v6`, `golangci-lint-action@v3 → v9`

**golangci-lint v1 → v2 migration** (required by action v9)
- Pin golangci-lint `v2.12.2`.
- Migrate `.golangci.yml` to the v2 format (via `golangci-lint migrate`; `legacy` exclusion preset preserves prior behavior).
- Drop the removed `--skip-files=xml` arg (already a no-op — no `*xml*` Go files).
- Fix the 3 `staticcheck` findings the v2 default set surfaces: `strings.Replace(..., -1)` → `strings.ReplaceAll`, and an untagged `switch{}` → tagged `switch dstDir{}`.

**Remove goreportcard-action**
- Drop the `creekorful/goreportcard-action@v1.0` step — unmaintained since 2020.

## Verification (locally, macOS has libpcap)
- `golangci-lint run` → 0 issues
- `go build ./...` → OK
- `go test ./...` → no test files